### PR TITLE
Remove NTP client application due to no device connected to BMS

### DIFF
--- a/target/linux/zynq/profile/zynq_bms7015_config
+++ b/target/linux/zynq/profile/zynq_bms7015_config
@@ -3376,7 +3376,7 @@ CONFIG_PACKAGE_ip-full=y
 #
 CONFIG_PACKAGE_ntp-keygen=y
 CONFIG_PACKAGE_ntp-utils=y
-CONFIG_PACKAGE_ntpclient=y
+# CONFIG_PACKAGE_ntpclient is not set
 # CONFIG_PACKAGE_ntpd is not set
 # CONFIG_PACKAGE_ntpdate is not set
 


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
